### PR TITLE
Add simple web search API

### DIFF
--- a/backend/fastapi/README_SEARCH_API.md
+++ b/backend/fastapi/README_SEARCH_API.md
@@ -1,0 +1,18 @@
+# Web検索API
+
+DuckDuckGoの検索結果を取得する簡易APIです。`/api/v1/search/` エンドポイントから利用できます。
+
+## 実装ファイル
+
+1. **スキーマ** (`app/schemas/search.py`)
+   - `SearchResponseItem`: 検索結果1件分の情報
+   - `SearchResponse`: 検索結果のリスト
+2. **サービス** (`app/services/web_search.py`)
+   - `WebSearchService.search`: DuckDuckGo APIを呼び出して結果を取得
+3. **APIエンドポイント** (`app/api/v1/search.py`)
+   - `GET /search/?q=キーワード`: 検索結果を取得
+
+## 使用例
+```bash
+curl "http://localhost:8000/api/v1/search/?q=fastapi"
+```

--- a/backend/fastapi/app/api/v1/__init__.py
+++ b/backend/fastapi/app/api/v1/__init__.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter
+
 from .bot import router as bot_router
 from .cat import router as cat_router
+from .search import router as search_router
 
 v1_router = APIRouter()
 
 v1_router.include_router(bot_router)
 v1_router.include_router(cat_router)
+v1_router.include_router(search_router)

--- a/backend/fastapi/app/api/v1/search.py
+++ b/backend/fastapi/app/api/v1/search.py
@@ -1,0 +1,15 @@
+from app.schemas.search import SearchResponse
+from app.services.web_search import WebSearchService
+from app.utils.logging import logger
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+@router.get("/", response_model=SearchResponse)
+async def search(q: str) -> SearchResponse:
+    try:
+        return await WebSearchService.search(q)
+    except Exception as e:
+        logger.error(f"検索APIエラー: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/fastapi/app/schemas/search.py
+++ b/backend/fastapi/app/schemas/search.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class SearchResponseItem(BaseModel):
+    title: str
+    url: str
+
+
+class SearchResponse(BaseModel):
+    results: list[SearchResponseItem]

--- a/backend/fastapi/app/services/web_search.py
+++ b/backend/fastapi/app/services/web_search.py
@@ -1,0 +1,49 @@
+import httpx
+
+from app.schemas.search import SearchResponse, SearchResponseItem
+from app.utils.logging import logger
+
+
+class WebSearchService:
+    @staticmethod
+    async def search(query: str) -> SearchResponse:
+        url = "https://api.duckduckgo.com/"
+        params = {"q": query, "format": "json", "no_redirect": 1, "no_html": 1}
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(url, params=params, timeout=10)
+                response.raise_for_status()
+                data = response.json()
+        except Exception as e:
+            logger.error(f"検索失敗: {str(e)}")
+            raise
+
+        results = []
+        for item in data.get("RelatedTopics", []):
+            # Skip nested lists
+            if (
+                isinstance(item, dict)
+                and "Text" in item
+                and "FirstURL" in item
+            ):
+                results.append(
+                    SearchResponseItem(
+                        title=item["Text"],
+                        url=item["FirstURL"],
+                    )
+                )
+            # Some items have 'Topics' list
+            elif "Topics" in item:
+                for sub in item.get("Topics", []):
+                    if (
+                        isinstance(sub, dict)
+                        and "Text" in sub
+                        and "FirstURL" in sub
+                    ):
+                        results.append(
+                            SearchResponseItem(
+                                title=sub["Text"],
+                                url=sub["FirstURL"],
+                            )
+                        )
+        return SearchResponse(results=results[:5])

--- a/backend/fastapi/pyproject.toml
+++ b/backend/fastapi/pyproject.toml
@@ -15,6 +15,7 @@ uvicorn = "^0.27.0"
 pydantic-settings = "^2.2.1"
 asyncpg = "^0.29.0"
 ulid-py = "^1.1.0"
+httpx = "^0.27.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## Summary
- add DuckDuckGo-based search service and API route
- include search schema definitions
- document new endpoint
- require `httpx` in poetry dependencies

## Testing
- `flake8 app/services/web_search.py app/schemas/search.py app/api/v1/search.py app/api/v1/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68482dfef4bc832581becafcf8afed67