### PR TITLE
Refactor database config and cleanup imports

### DIFF
--- a/backend/fastapi/app/db/database.py
+++ b/backend/fastapi/app/db/database.py
@@ -1,23 +1,19 @@
 from typing import Any, AsyncGenerator
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import declarative_base, sessionmaker
-from app.settings import settings
 from urllib.parse import quote_plus
-from app.utils.logging import logger
 
-ai_bot_db_user: str = settings.ai_bot_db_user
-ai_bot_db_password: str = quote_plus(settings.ai_bot_db_password)
-ai_bot_db_name: str = settings.ai_bot_db_name
-ai_bot_db_host: str = settings.ai_bot_db_host
-ai_bot_cloud_sql_connection_name: str = settings.ai_bot_cloud_sql_connection_name
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from app.settings import settings
+from app.utils.logging import logger
 
 
 def _get_database_url() -> str:
-    from app.settings import Settings
-
-    settings = Settings()
-
-    return f"postgresql+asyncpg://{settings.ai_bot_db_user}:{settings.ai_bot_db_password}@{settings.ai_bot_db_host}:5432/{settings.ai_bot_db_name}"
+    password = quote_plus(settings.ai_bot_db_password)
+    return (
+        f"postgresql+asyncpg://{settings.ai_bot_db_user}:{password}"
+        f"@{settings.ai_bot_db_host}:5432/{settings.ai_bot_db_name}"
+    )
 
 
 DATABASE_URL: str = _get_database_url()

--- a/backend/fastapi/app/services/cat.py
+++ b/backend/fastapi/app/services/cat.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from typing import List
 
 from app.models.cat import Cat
 from app.schemas.cat import (


### PR DESCRIPTION
## Summary
- centralize DB settings usage and escape the password
- remove unused typing import in `CatService`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68529fb07c8883259c9716878f688aa7