### PR TITLE
Add Next.js frontend with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Node
+node_modules/
+.next/
+
+# Python virtualenv
+.venv/
+
+# Docker
+**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# FastAPI and Next.js Demo
+
+This project includes a FastAPI backend and a Next.js frontend. Both services are started using Docker Compose.
+
+## Development
+
+```
+docker-compose up --build
+```
+
+- FastAPI: http://localhost:8000
+- Next.js: http://localhost:3000
+
+The frontend has access to the backend via the `NEXT_PUBLIC_API_URL` environment variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     depends_on:
       - fastapi
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8000
+      - NEXT_PUBLIC_API_URL=http://fastapi:8000
     networks:
       - app_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,22 @@ services:
       - ai_bot_cloud_sql_connection_name=local
       - environment=development
 
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: nextjs_frontend
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - fastapi
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8000
+    networks:
+      - app_network
+
 volumes:
   postgres_data:
     driver: local

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+dist
+.next

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone'
+}
+
+export default nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nextjs-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to Next.js</h1>
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js app in `frontend`
- add frontend service to compose
- document how to start services
- add `.gitignore`

## Testing
- `docker compose version` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68652d619284832598e2ce5a4b9b0873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Next.jsフロントエンドの初期セットアップを追加しました。
  * FastAPIバックエンドとNext.jsフロントエンドをDocker Composeで同時に起動できるようになりました。
  * フロントエンドに「Welcome to Next.js」と表示されるトップページを追加しました。

* **ドキュメント**
  * プロジェクトの概要と起動方法を記載したREADMEを追加しました。

* **その他**
  * 開発環境やビルド生成物を除外するための.gitignoreおよび.dockerignoreファイルを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->